### PR TITLE
Copy image if expanding by zero

### DIFF
--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -232,6 +232,7 @@ def test_invalid_box_blur_filter(radius: int | tuple[int, int]) -> None:
 
 def test_rankfilter_size_1() -> None:
     im = Image.new("L", (3, 3), 128)
+
     # Size 1 should not crash (margin is 0)
     assert im.filter(ImageFilter.MinFilter(1)).getpixel((1, 1)) == 128
     assert im.filter(ImageFilter.MaxFilter(1)).getpixel((1, 1)) == 128

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -1115,6 +1115,9 @@ _expand_image(ImagingObject *self, PyObject *args) {
         return NULL;
     }
 
+    if (m == 0) {
+        return PyImagingNew(ImagingCopy(self->image));
+    }
     return PyImagingNew(ImagingExpand(self->image, m));
 }
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/9755

Rather than expand the image by zero, I think just copying the image would be more efficient.

You probably want to keep `margin > 0` for defensiveness.